### PR TITLE
Fix socketcall() on Browsix

### DIFF
--- a/src/library_sockfs.js
+++ b/src/library_sockfs.js
@@ -1,5 +1,5 @@
 mergeInto(LibraryManager.library, {
-  $SOCKFS__postset: '__ATINIT__.push(function() { SOCKFS.root = FS.mount(SOCKFS, {}, null); });',
+  $SOCKFS__postset: '__ATINIT__.push(function() { if (!ENVIRONMENT_IS_BROWSIX) SOCKFS.root = FS.mount(SOCKFS, {}, null); });',
   $SOCKFS__deps: ['$FS'],
   $SOCKFS: {
     mount: function(mount) {


### PR DESCRIPTION
Like d61ee2a, adds back a condition removed in d006af9.